### PR TITLE
feat(manager): Do not persist mongodb client connections

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -1,9 +1,9 @@
 .PHONY: coverage testclean package package.xml
 
 DATE=`date +%Y-%m-%d--%H-%M-%S`
-MONGODB_VERSION=$(shell php -n -dextension=modules/mongodb.so -r 'echo MONGODB_VERSION;')
+MONGODB_VERSION=$(shell php -dextension=modules/mongodb.so -r 'echo MONGODB_VERSION;')
 MONGODB_MINOR=$(shell echo $(MONGODB_VERSION) | cut -d. -f1,2)
-MONGODB_STABILITY=$(shell php -n -dextension=modules/mongodb.so -r 'echo MONGODB_STABILITY;')
+MONGODB_STABILITY=$(shell php -dextension=modules/mongodb.so -r 'echo MONGODB_STABILITY;')
 
 help:
 	@echo -e "\t$$ make vm"

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1976,8 +1976,7 @@ void phongo_manager_init(php_phongo_manager_t *manager, const char *uri_string, 
 	}
 #endif
 
-	MONGOC_DEBUG("Created client hash: %s\n", hash);
-	php_phongo_persist_client(hash, hash_len, manager->client TSRMLS_CC);
+	MONGOC_DEBUG("Created client hash: %s but we do not persist!\n", hash);
 
 cleanup:
 	if (hash) {

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -25,7 +25,7 @@
 extern zend_module_entry mongodb_module_entry;
 
 /* FIXME: Its annoying to bump version. Move into phongo_version.h.in */
-#define PHP_MONGODB_VERSION "1.3.5-dev"
+#define PHP_MONGODB_VERSION "1.3.5"
 #define PHP_MONGODB_STABILITY "devel"
 
 /* Structure for persisted libmongoc clients. The PID is included to ensure that

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -532,7 +532,8 @@ static void php_phongo_manager_free_object(phongo_free_object_arg *object TSRMLS
 	zend_object_std_dtor(&intern->std TSRMLS_CC);
 
 	if (intern->client) {
-		MONGOC_DEBUG("Not destroying persistent client for Manager");
+		MONGOC_DEBUG("CHANGED: We destroy the client when the manager dies.");
+		mongoc_client_destroy(intern->client);
 		intern->client = NULL;
 	}
 


### PR DESCRIPTION
This would result in disabling persistent connections to MongoDB. This is necessary on some of the older versions of MongoDB that we are using since we are at a high scale and can not change the compiled-in connection limit.